### PR TITLE
Remove support for Yosemite and older

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,3 @@ matrix:
           os: osx
           osx_image: xcode7.3
           rvm: system
-        - env: macos=10.10 PACKAGE=moira
-          os: osx
-          osx_image: xcode6.4
-          rvm: system

--- a/moira.rb
+++ b/moira.rb
@@ -4,6 +4,7 @@ class Moira < Formula
   url "https://github.com/mit-athena/moira/archive/4.0.0.3+51+g65d55c5.tar.gz"
   sha256 "d418681ae4ec61a124c55fb67a6bba0d89b59dc760c4d1c9a1e8e1c9c7b69b19"
 
+  depends_on :macos => :el_capitan
   depends_on "hesiod"
   depends_on "krb5"
 


### PR DESCRIPTION
I propose we stop supporting macOS versions older than 10.10, and mandate users to have at least 10.11 in order to use MacAthena packages. This comes as Apple no longer is issuing security updates for Yosemite.